### PR TITLE
[컨텐츠 카드] 상세 보기 API 구현

### DIFF
--- a/src/common/storage/multer-s3.storage.ts
+++ b/src/common/storage/multer-s3.storage.ts
@@ -1,5 +1,5 @@
 import { UnsupportedMediaTypeException } from '@nestjs/common';
-import { AWS_S3_BUCKET_NAME, s3 } from '@src/config/aws.config';
+import { AWS_S3_BUCKET_NAME, EXT_LIST, s3 } from '@src/config/aws.config';
 import { Request } from 'express';
 import * as multerS3 from 'multer-s3';
 

--- a/src/config/aws.config.ts
+++ b/src/config/aws.config.ts
@@ -5,6 +5,8 @@ config({
   path: `.env.${process.env.NODE_ENV}`,
 });
 
+export const EXT_LIST = ['jpg', 'png'];
+
 export const AWS_S3_BUCKET_NAME = process.env.AWS_S3_BUCKET_NAME;
 
 export const s3 = new S3Client({

--- a/src/config/db.config.ts
+++ b/src/config/db.config.ts
@@ -1,8 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { TypeOrmModuleOptions, TypeOrmOptionsFactory } from '@nestjs/typeorm';
-import { ContentEntity } from '@src/entities/content.entity';
+import {
+  ContentEntity,
+  ContentSourceEntity,
+} from '@src/entities/content.entity';
 import { LikesEntity } from '@src/entities/likes.entity';
+import { SeriesEntity } from '@src/entities/series.entity';
 import { TagEntity, TagNameEntity } from '@src/entities/tag.entity';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 
@@ -20,7 +24,14 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
       database: this.configService.get('DB_NAME'),
       synchronize: true,
       logging: process.env.NODE_ENV === 'dev',
-      entities: [TagEntity, TagNameEntity, ContentEntity, LikesEntity],
+      entities: [
+        TagEntity,
+        TagNameEntity,
+        ContentEntity,
+        ContentSourceEntity,
+        LikesEntity,
+        SeriesEntity,
+      ],
       namingStrategy: new SnakeNamingStrategy(),
     };
   }

--- a/src/content/content.controller.ts
+++ b/src/content/content.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get } from '@nestjs/common';
-import { Query } from '@nestjs/common/decorators';
+import { Controller, Get, ParseIntPipe } from '@nestjs/common';
+import { Param, Query } from '@nestjs/common/decorators';
 import {
   ApiBearerAuth,
   ApiOkResponse,
@@ -7,7 +7,12 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { Profile, User } from '@src/common/decorator/user.decorator';
-import { ContentDto, ContentResultDto } from '@src/dto/content.dto';
+import {
+  ContentCardDto,
+  ContentDetailDto,
+  ContentDto,
+  ContentResultDto,
+} from '@src/dto/content.dto';
 import { UserProfile } from '@src/interfaces/user.interface';
 import { ContentService } from './content.service';
 
@@ -15,6 +20,7 @@ import { ContentService } from './content.service';
  * 컨텐츠 Controller
  *
  * - GET /content
+ * - GET /content/:seq
  */
 @ApiTags('content')
 @Controller('content')
@@ -27,17 +33,29 @@ export class ContentController {
     type: ContentDto,
   })
   @ApiOkResponse({ type: ContentResultDto })
-  async getContent(
+  async getContents(
     @User() user: number,
     @Profile() profile: UserProfile | null,
     @Query() dto: ContentDto,
   ): Promise<ContentResultDto> {
-    const [content, count] = await this.contentService.getContent(
+    const [content, count] = await this.contentService.getContents(
       user,
       profile,
       dto,
     );
     const pageCount = Math.ceil(count / dto.count);
     return new ContentResultDto({ pageCount, content });
+  }
+
+  @Get(':seq')
+  @ApiBearerAuth()
+  @ApiOkResponse({ type: ContentCardDto })
+  async getContent(
+    @User() user: number,
+    @Profile() profile: UserProfile | null,
+    @Param('seq', ParseIntPipe) seq: number,
+  ): Promise<ContentDetailDto> {
+    const content = await this.contentService.getContent(user, profile, seq);
+    return new ContentDetailDto(content);
   }
 }

--- a/src/dto/content.dto.ts
+++ b/src/dto/content.dto.ts
@@ -1,11 +1,17 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Content } from '@src/interfaces/content.interface';
+import {
+  Content,
+  ContentSource,
+  Series,
+  SourceType,
+} from '@src/interfaces/content.interface';
 import { Exclude, Expose, Transform, Type } from 'class-transformer';
 import { IsInt, Min } from '@src/common/validator';
 import { TagResultDto } from './tag.dto';
 import { IsOptional } from 'class-validator';
 import { BaseDto } from './base.dto';
 import { Likes } from '@src/interfaces/likes.interface';
+import { SeriesDto } from './series.dto';
 
 export class ContentDto extends BaseDto {
   @IsInt()
@@ -108,7 +114,53 @@ export class ContentCardDto extends BaseDto implements Content {
   })
   artist: TagResultDto;
 
+  status: boolean;
+
   likes: Likes[];
+
+  source: ContentSource[];
+
+  series: Series;
+}
+@Exclude()
+class ContentSourceDto extends BaseDto implements ContentSource {
+  @Expose()
+  @ApiProperty({
+    enum: SourceType,
+    description: '출처 종류',
+  })
+  type: SourceType;
+
+  @Expose()
+  @ApiProperty({
+    type: String,
+    description: '출처',
+  })
+  link: string;
+
+  content: Content;
+}
+
+@Exclude()
+export class ContentDetailDto extends ContentCardDto {
+  @Expose()
+  @Type(() => ContentSourceDto)
+  @ApiProperty({
+    type: ContentSourceDto,
+    description: '원작/번역 출처',
+  })
+  source: ContentSourceDto[];
+
+  @Expose()
+  @Type(() => SeriesDto)
+  @ApiProperty({
+    type: SeriesDto,
+    description: '시리즈',
+  })
+  series: SeriesDto;
+
+  @Exclude()
+  artist: TagResultDto;
 }
 
 export class ContentResultDto extends BaseDto {

--- a/src/dto/series.dto.ts
+++ b/src/dto/series.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Content, Series } from '@src/interfaces/content.interface';
+import { Exclude, Expose } from 'class-transformer';
+import { BaseDto } from './base.dto';
+import { ContentCardDto } from './content.dto';
+
+@Exclude()
+export class SeriesDto extends BaseDto implements Series {
+  @Expose()
+  @ApiProperty({
+    type: Number,
+    description: '고유 아이디',
+  })
+  seq: number;
+
+  @Expose()
+  @ApiProperty({
+    type: String,
+    description: '시리즈 제목',
+  })
+  title: string;
+
+  content: Content[];
+}
+
+@Exclude()
+export class SeriesWithContentDto extends SeriesDto {
+  @Expose()
+  @ApiProperty({
+    type: [ContentCardDto],
+    description: '컨텐츠 카드',
+  })
+  content: ContentCardDto[];
+}

--- a/src/entities/content.entity.ts
+++ b/src/entities/content.entity.ts
@@ -1,4 +1,8 @@
-import { Content } from '@src/interfaces/content.interface';
+import {
+  Content,
+  ContentSource,
+  SourceType,
+} from '@src/interfaces/content.interface';
 import {
   Entity,
   Column,
@@ -9,6 +13,7 @@ import {
 } from 'typeorm';
 import { BaseEntity } from './base.entity';
 import { LikesEntity } from './likes.entity';
+import { SeriesEntity } from './series.entity';
 import { TagEntity } from './tag.entity';
 
 @Entity({ name: 'tb_content' })
@@ -20,10 +25,16 @@ export class ContentEntity extends BaseEntity implements Content {
   thumbnail: string;
 
   @Column()
+  uploaderSeq: number;
+
+  @Column()
   translateReview: string;
 
   @Column()
   isAdult: boolean;
+
+  @Column()
+  status: boolean;
 
   // typeorm의 .addSelectAndMap 기능이 현재 존재하지 않아 있는 임시 컬럼...
   @Column({ select: false, nullable: true, insert: false, update: false })
@@ -35,6 +46,9 @@ export class ContentEntity extends BaseEntity implements Content {
 
   @ManyToOne(() => TagEntity, (tag) => tag.work)
   artist: TagEntity;
+
+  @ManyToOne(() => SeriesEntity, (series) => series.content)
+  series: SeriesEntity;
 
   @ManyToMany(() => TagEntity)
   @JoinTable({
@@ -52,4 +66,24 @@ export class ContentEntity extends BaseEntity implements Content {
 
   @OneToMany(() => LikesEntity, (like) => like.content, { cascade: true })
   likes: LikesEntity[];
+
+  @OneToMany(() => ContentSourceEntity, (source) => source.content, {
+    cascade: true,
+  })
+  source: ContentSourceEntity[];
+}
+
+@Entity({ name: 'tb_content_source' })
+export class ContentSourceEntity extends BaseEntity implements ContentSource {
+  @Column({
+    type: 'enum',
+    enum: SourceType,
+  })
+  type: SourceType;
+
+  @Column()
+  link: string;
+
+  @ManyToOne(() => ContentEntity, (content) => content.source)
+  content: ContentEntity;
 }

--- a/src/entities/series.entity.ts
+++ b/src/entities/series.entity.ts
@@ -1,0 +1,13 @@
+import { Series } from '@src/interfaces/content.interface';
+import { Column, Entity, OneToMany } from 'typeorm';
+import { BaseEntity } from './base.entity';
+import { ContentEntity } from './content.entity';
+
+@Entity({ name: 'tb_series' })
+export class SeriesEntity extends BaseEntity implements Series {
+  @Column()
+  title: string;
+
+  @OneToMany(() => ContentEntity, (content) => content.series)
+  content: ContentEntity[];
+}

--- a/src/entities/tag.entity.ts
+++ b/src/entities/tag.entity.ts
@@ -8,7 +8,6 @@ export class TagEntity extends BaseEntity implements Tag {
   @Column({
     type: 'enum',
     enum: TagTypes,
-    default: TagTypes.ATTRIBUTE,
   })
   type: TagTypes;
 

--- a/src/interfaces/content.interface.ts
+++ b/src/interfaces/content.interface.ts
@@ -6,9 +6,28 @@ export interface Content {
   thumbnail: string;
   translateReview: string;
   isAdult: boolean;
+  status: boolean;
   like: number;
   doLike: boolean;
   artist: Tag;
   tags: Tag[];
   likes: Likes[];
+  source: ContentSource[];
+  series: Series;
+}
+
+export interface ContentSource {
+  type: SourceType;
+  link: string;
+  content: Content;
+}
+
+export interface Series {
+  title: string;
+  content: Content[];
+}
+
+export enum SourceType {
+  ARTIST,
+  TRANSLATOR,
 }

--- a/src/rabbitmq/rabbit.service.ts
+++ b/src/rabbitmq/rabbit.service.ts
@@ -1,13 +1,11 @@
 import { CopyObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { RabbitRPC } from '@golevelup/nestjs-rabbitmq';
 import { Injectable } from '@nestjs/common';
-import { AWS_S3_BUCKET_NAME, s3 } from '@src/config/aws.config';
+import { AWS_S3_BUCKET_NAME, EXT_LIST, s3 } from '@src/config/aws.config';
 import { ProfileFormDto, ProfileFormResultDto } from '@src/dto/upload.dto';
 
 @Injectable()
 export class RabbitService {
-  private EXT_LIST = ['jpg', 'png'];
-
   @RabbitRPC({
     exchange: 'fanfixiv.main',
     routingKey: 'profile-img.form',
@@ -21,7 +19,7 @@ export class RabbitService {
 
       const [nameCheck, extCheck] = realKey.split('.');
 
-      if (!/[^0-9]/.test(nameCheck) || !this.EXT_LIST.includes(extCheck)) {
+      if (!/[^0-9]/.test(nameCheck) || !EXT_LIST.includes(extCheck)) {
         throw new Error('프로필 이미지 링크가 올바르지 않습니다.');
       }
 

--- a/test/content-like.e2e-spec.ts
+++ b/test/content-like.e2e-spec.ts
@@ -172,6 +172,8 @@ describe('ContentController, LikesController (e2e)', () => {
         translateReview: '번역 후기',
         tags: [testTag1],
         artist: testTagArtist,
+        status: true,
+        uploaderSeq: -1,
       }),
     );
 
@@ -184,6 +186,8 @@ describe('ContentController, LikesController (e2e)', () => {
         translateReview: '번역 후기',
         tags: [testTag2],
         artist: testTagArtist,
+        status: true,
+        uploaderSeq: -1,
       }),
     );
 
@@ -196,6 +200,8 @@ describe('ContentController, LikesController (e2e)', () => {
         translateReview: '번역 후기',
         tags: [testTag1, testTag2],
         artist: testTagArtist,
+        status: true,
+        uploaderSeq: -1,
       }),
     );
 
@@ -208,6 +214,8 @@ describe('ContentController, LikesController (e2e)', () => {
         translateReview: '번역 후기',
         tags: [testTag1, testTag2],
         artist: testTagArtist,
+        status: true,
+        uploaderSeq: -1,
       }),
     );
   });


### PR DESCRIPTION
**PR 설명**
컨텐츠 카드 상세보기와 관련된 API를 구현하였습니다. 해당 기능의 개발을 위해 DB 수정이 존재합니다.

**개발된 기능**
- `GET /content/:seq` API 추가
- SeriesEntity 추가
- ContentSourceEntity 추가

**레퍼런스**
- https://typeorm.io/
