### PR TITLE
[만화 뷰어] 만화 뷰어 API 추가

### DIFF
--- a/src/config/db.config.ts
+++ b/src/config/db.config.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { TypeOrmModuleOptions, TypeOrmOptionsFactory } from '@nestjs/typeorm';
 import {
   ContentEntity,
+  ContentImageEntity,
   ContentSourceEntity,
 } from '@src/entities/content.entity';
 import { ArtistProfileEntity } from '@src/entities/artist-profile.entity';
@@ -30,6 +31,7 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
         TagNameEntity,
         ContentEntity,
         ContentSourceEntity,
+        ContentImageEntity,
         SeriesEntity,
         LikesEntity,
         ArtistProfileEntity,

--- a/src/content/content.controller.ts
+++ b/src/content/content.controller.ts
@@ -8,10 +8,10 @@ import {
 } from '@nestjs/swagger';
 import { Profile, User } from '@src/common/decorator/user.decorator';
 import {
-  ContentCardDto,
   ContentDetailDto,
   ContentDto,
   ContentResultDto,
+  ContentViewDto,
 } from '@src/dto/content.dto';
 import { UserProfile } from '@src/interfaces/user.interface';
 import { ContentService } from './content.service';
@@ -21,6 +21,7 @@ import { ContentService } from './content.service';
  *
  * - GET /content
  * - GET /content/:seq
+ * - GET /content/view/:seq
  */
 @ApiTags('content')
 @Controller('content')
@@ -49,7 +50,7 @@ export class ContentController {
 
   @Get(':seq')
   @ApiBearerAuth()
-  @ApiOkResponse({ type: ContentCardDto })
+  @ApiOkResponse({ type: ContentDetailDto })
   async getContent(
     @User() user: number,
     @Profile() profile: UserProfile | null,
@@ -57,5 +58,21 @@ export class ContentController {
   ): Promise<ContentDetailDto> {
     const content = await this.contentService.getContent(user, profile, seq);
     return new ContentDetailDto(content);
+  }
+
+  @Get('view/:seq')
+  @ApiBearerAuth()
+  @ApiOkResponse({ type: ContentViewDto })
+  async getContentView(
+    @User() user: number,
+    @Profile() profile: UserProfile | null,
+    @Param('seq', ParseIntPipe) seq: number,
+  ): Promise<ContentViewDto> {
+    const content = await this.contentService.getContentView(
+      user,
+      profile,
+      seq,
+    );
+    return new ContentViewDto(content);
   }
 }

--- a/src/content/content.service.ts
+++ b/src/content/content.service.ts
@@ -272,4 +272,66 @@ export class ContentService {
 
     return result;
   }
+
+  /**
+   * @param user 사용자 고유번호
+   * @param profile IProfile
+   * @param profile.birth 사용자의 생일
+   * @param seq 컨텐츠 SEQ
+   * @return 컨텐츠 목록
+   */
+  async getContentView(
+    user: number,
+    profile: UserProfile | null,
+    seq: number,
+  ): Promise<ContentEntity> {
+    const result = await this.contentRepository
+      .createQueryBuilder('content')
+      .leftJoinAndSelect('content.source', 'source')
+      .leftJoinAndSelect('content.series', 'series')
+      .leftJoinAndSelect('content.imgs', 'imgs')
+      .leftJoin(
+        (sub) =>
+          sub
+            .subQuery()
+            .select('like.content_seq', 'like_content_seq')
+            .addSelect('COUNT(seq)', 'like')
+            .from(LikesEntity, 'like')
+            .groupBy('like.content_seq'),
+        'like',
+        '"like"."like_content_seq" = content.seq',
+      )
+      .leftJoin(
+        (sub) =>
+          sub
+            .subQuery()
+            .select('like.content_seq', 'like_content_seq')
+            .addSelect('COUNT(seq) > 0', 'do_like')
+            .from(LikesEntity, 'like')
+            .where('like.user_seq = :user', { user })
+            .groupBy('like.content_seq'),
+        'do_like',
+        '"do_like"."like_content_seq" = content.seq',
+      )
+      .addSelect('COALESCE("like"."like", 0)', 'content_like')
+      .addSelect('COALESCE("do_like"."do_like", false)', 'content_do_like')
+      .where('(content.status)')
+      .andWhere(
+        `(not content."is_adult" 
+        or (
+          content."is_adult" and EXTRACT( year FROM age(CURRENT_DATE, :birth)) >= 18))`,
+        {
+          birth: profile?.birth ?? '3000-01-01',
+        },
+      )
+      .andWhere('content.seq = :seq', { seq })
+      .orderBy('imgs.seq', 'ASC')
+      .getOne();
+
+    if (result == null) {
+      throw new BadRequestException('해당 컨텐츠가 존재하지 않습니다.');
+    }
+
+    return result;
+  }
 }

--- a/src/dto/content.dto.ts
+++ b/src/dto/content.dto.ts
@@ -2,6 +2,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   Content,
   ContentSource,
+  Image,
   Series,
   SourceType,
 } from '@src/interfaces/content.interface';
@@ -122,6 +123,7 @@ export class ContentCardDto extends BaseDto implements Content {
 
   series: Series;
 }
+
 @Exclude()
 class ContentSourceDto extends BaseDto implements ContentSource {
   @Expose()
@@ -131,6 +133,18 @@ class ContentSourceDto extends BaseDto implements ContentSource {
   })
   type: SourceType;
 
+  @Expose()
+  @ApiProperty({
+    type: String,
+    description: '출처',
+  })
+  link: string;
+
+  content: Content;
+}
+
+@Exclude()
+class ContentImageDto extends BaseDto implements Image {
   @Expose()
   @ApiProperty({
     type: String,
@@ -161,6 +175,20 @@ export class ContentDetailDto extends ContentCardDto {
 
   @Exclude()
   artist: TagResultDto;
+}
+
+@Exclude()
+export class ContentViewDto extends ContentDetailDto {
+  @Expose()
+  @Transform(({ value }) => value.map((x: ContentImageDto) => x.link))
+  @ApiProperty({
+    type: [String],
+    description: '이미지 주소',
+  })
+  imgs: string[];
+
+  @Exclude()
+  tags: TagResultDto[];
 }
 
 export class ContentResultDto extends BaseDto {

--- a/src/entities/content.entity.ts
+++ b/src/entities/content.entity.ts
@@ -2,6 +2,7 @@ import {
   Content,
   ContentSource,
   SourceType,
+  Image,
 } from '@src/interfaces/content.interface';
 import {
   Entity,
@@ -71,6 +72,9 @@ export class ContentEntity extends BaseEntity implements Content {
     cascade: true,
   })
   source: ContentSourceEntity[];
+
+  @OneToMany(() => ContentImageEntity, (img) => img.content)
+  imgs: ContentImageEntity[];
 }
 
 @Entity({ name: 'tb_content_source' })
@@ -85,5 +89,14 @@ export class ContentSourceEntity extends BaseEntity implements ContentSource {
   link: string;
 
   @ManyToOne(() => ContentEntity, (content) => content.source)
+  content: ContentEntity;
+}
+
+@Entity({ name: 'tb_img' })
+export class ContentImageEntity extends BaseEntity implements Image {
+  @Column()
+  link: string;
+
+  @ManyToOne(() => ContentEntity, (content) => content.imgs)
   content: ContentEntity;
 }

--- a/src/interfaces/content.interface.ts
+++ b/src/interfaces/content.interface.ts
@@ -22,6 +22,11 @@ export interface ContentSource {
   content: Content;
 }
 
+export interface Image {
+  link: string;
+  content: Content;
+}
+
 export interface Series {
   title: string;
   content: Content[];

--- a/test/content-view.e2e-spec.ts
+++ b/test/content-view.e2e-spec.ts
@@ -1,0 +1,229 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  ClassSerializerInterceptor,
+  INestApplication,
+  ValidationPipe,
+} from '@nestjs/common';
+import * as request from 'supertest';
+import {
+  ContentEntity,
+  ContentImageEntity,
+  ContentSourceEntity,
+} from '@src/entities/content.entity';
+import { Repository } from 'typeorm';
+import { TagEntity } from '@src/entities/tag.entity';
+import { getRepositoryToken, TypeOrmModule } from '@nestjs/typeorm';
+import { TagTypes } from '@src/interfaces/tag.interface';
+import { instanceToPlain } from 'class-transformer';
+import { ContentViewDto } from '@src/dto/content.dto';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmConfigService } from '@src/config/db.config';
+import { ContentModule } from '@src/content/content.module';
+import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
+import { JwtAuthGuard } from '@src/common/guard/jwt-auth.guard';
+import { JwtStrategy } from '@src/common/strategy/jwt.strategy';
+import { SeriesEntity } from '@src/entities/series.entity';
+import { SourceType } from '@src/interfaces/content.interface';
+
+describe('ContentController - View (e2e)', () => {
+  let app: INestApplication;
+  let module: TestingModule;
+
+  let tagRepository: Repository<TagEntity>;
+  let contentRepository: Repository<ContentEntity>;
+  let imgRepository: Repository<ContentImageEntity>;
+  let contentSourceRepository: Repository<ContentSourceEntity>;
+  let seriesRepository: Repository<SeriesEntity>;
+
+  let testArtistTag: TagEntity;
+
+  const testImages: ContentImageEntity[] = [];
+
+  let contentSource: ContentSourceEntity;
+
+  let series: SeriesEntity;
+
+  let contentTest: ContentEntity;
+  let contentTestStatusFalse: ContentEntity;
+
+  function contentToPlain(contents: ContentEntity) {
+    contents.imgs = testImages;
+    const content = new ContentViewDto(contents);
+    content.like = 0;
+    content.doLike = false;
+    const plain = instanceToPlain(content);
+    plain.createdAt = (plain.createdAt as Date).toISOString();
+    return plain;
+  }
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          envFilePath: `.env.${process.env.NODE_ENV}`,
+        }),
+        TypeOrmModule.forRootAsync({
+          useClass: TypeOrmConfigService,
+        }),
+        TypeOrmModule.forFeature([
+          SeriesEntity,
+          ContentSourceEntity,
+          ContentImageEntity,
+        ]),
+        ContentModule,
+      ],
+      providers: [
+        JwtStrategy,
+        {
+          provide: APP_INTERCEPTOR,
+          useClass: ClassSerializerInterceptor,
+        },
+        {
+          provide: APP_GUARD,
+          useClass: JwtAuthGuard,
+        },
+        {
+          provide: getRepositoryToken(TagEntity),
+          useClass: Repository<TagEntity>,
+        },
+        {
+          provide: getRepositoryToken(ContentEntity),
+          useClass: Repository<ContentEntity>,
+        },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+
+    tagRepository = module.get<Repository<TagEntity>>(
+      getRepositoryToken(TagEntity),
+    );
+    contentRepository = module.get<Repository<ContentEntity>>(
+      getRepositoryToken(ContentEntity),
+    );
+    imgRepository = module.get<Repository<ContentImageEntity>>(
+      getRepositoryToken(ContentImageEntity),
+    );
+    contentSourceRepository = module.get<Repository<ContentSourceEntity>>(
+      getRepositoryToken(ContentSourceEntity),
+    );
+    seriesRepository = module.get<Repository<SeriesEntity>>(
+      getRepositoryToken(SeriesEntity),
+    );
+
+    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+
+    await app.init();
+
+    testArtistTag = await tagRepository.save(
+      new TagEntity({
+        type: TagTypes.ARTIST,
+        name: '컨텐츠-뷰 테스트 작가',
+        description: '테스트용 작가입니다.',
+        status: true,
+        isAdult: false,
+      }),
+    );
+
+    series = await seriesRepository.save(
+      new SeriesEntity({
+        title: '컨텐츠-뷰 테스트 시리즈',
+      }),
+    );
+
+    contentSource = await contentSourceRepository.save(
+      new ContentSourceEntity({
+        type: SourceType.ARTIST,
+        link: 'http://example.com',
+      }),
+    );
+
+    contentTestStatusFalse = await contentRepository.save(
+      new ContentEntity({
+        createdAt: new Date(),
+        title: '컨텐츠-뷰 테스트 컨텐츠',
+        thumbnail: 'http://example.com/image.jpg',
+        isAdult: false,
+        translateReview: '번역 후기',
+        tags: [testArtistTag],
+        series: series,
+        source: [contentSource],
+        artist: testArtistTag,
+        status: false,
+        uploaderSeq: -1,
+      }),
+    );
+
+    contentTest = await contentRepository.save(
+      new ContentEntity({
+        createdAt: new Date(),
+        title: '컨텐츠-뷰 테스트 컨텐츠',
+        thumbnail: 'http://example.com/image.jpg',
+        isAdult: false,
+        translateReview: '번역 후기',
+        tags: [testArtistTag],
+        series: series,
+        source: [contentSource],
+        artist: testArtistTag,
+        status: true,
+        uploaderSeq: -1,
+      }),
+    );
+
+    for (let i = 0; i < 5; i++) {
+      const img = await imgRepository.save(
+        new ContentImageEntity({
+          link: `http://example.com/${i}`,
+          content: contentTest,
+        }),
+      );
+      testImages.push(img);
+    }
+  });
+
+  describe('/content (GET)', () => {
+    let result: Record<string, any>;
+
+    beforeAll(async () => {
+      result = contentToPlain(contentTest);
+    });
+
+    test('200', () => {
+      return request(app.getHttpServer())
+        .get(`/content/view/${contentTest.seq}`)
+        .expect(200)
+        .expect(result);
+    });
+
+    test('400 (NO SEQ)', () => {
+      return request(app.getHttpServer())
+        .get(`/content/view/${contentTest.seq + 100}`)
+        .expect(400);
+    });
+
+    test('400 (Status False)', () => {
+      return request(app.getHttpServer())
+        .get(`/content/view/${contentTestStatusFalse.seq}`)
+        .expect(400);
+    });
+
+    test('400 (Wrong SEQ)', () => {
+      return request(app.getHttpServer()).get(`/content/view/test`).expect(400);
+    });
+  });
+
+  afterAll(async () => {
+    for (let i = 0; i < 5; i++) {
+      await imgRepository.remove(testImages[i]);
+    }
+    await contentSourceRepository.remove(contentSource);
+    await contentRepository.remove(contentTest);
+    await contentRepository.remove(contentTestStatusFalse);
+    await tagRepository.remove(testArtistTag);
+    await seriesRepository.remove(series);
+
+    await app.close();
+    await module.close();
+  });
+});


### PR DESCRIPTION
**PR 설명**
만화 뷰어 API를 생성하였습니다.

**개발된 기능**
- 만화 뷰어 API 추가
    - 만화 이미지 리스트 기능 추가
    - 해당 유저의 업로더 여부 추가

**레퍼런스**
없음
